### PR TITLE
plusieurs petites modifications

### DIFF
--- a/fantoir_annule.html
+++ b/fantoir_annule.html
@@ -203,8 +203,6 @@
 				//Nom OSM
 				$('#'+table+' tr:last').append($('<td>').text(data[l][1]))
 				//Date d'annulation
-				$('#'+table+' tr:last').append($('<td>').text(data[l][5]))
-				//transfert
 				$('#'+table+' tr:last').append($('<td>').text(data[l][4]))
 				lon = data[l][2]
 				lat = data[l][3]
@@ -269,7 +267,6 @@
 		$('#'+table).append($('<tr>').append($('<th>').append('Code FANTOIR')))
 		$('#'+table+' tr').append($('<th>').append('Voie OSM'))
 		$('#'+table+' tr').append($('<th>').append('Date d\'annulation'))
-		$('#'+table+' tr').append($('<th>').append('Avec ou sans transfert'))
 		if (with_edit_and_map_links){
 			$('#'+table+' tr').append($('<th>').attr('colspan','3').append('Cartes'))
 			$('#'+table+' tr').append($('<th>').attr('colspan','3').append('Édition'))
@@ -282,7 +279,7 @@
 <body onload="start()">
 <div id="bandeau">
 <h1></h1>
-<h4>Liste des codes Fantoir trouvés dans OSM et qui ont été annulés d'après le fichier Fantoir officiel.</h4>
+<h4>Liste des codes Fantoir trouvés dans OSM et qui ont été annulés d'après le fichier Fantoir officiel.<br>Cela peux être des noms de voies  remplacés par d'autres, des voies en double dont un seul code est conservé...<br>Lors de fusions de communes, les codes fantoirs des voies des communes dont le code insee disparait ont toutes leurs codes fantoir annulés et remplacés par de nouveaux dans la nouvelle commune donc dans ce cas c'est dans la page de la nouvelle commune qu'il faut chercher le nouveau code fantoir.</h4>
 <div id="pied_de_page"></div>
 </div>
 <table id="rubriques">

--- a/fantoir_annule.html
+++ b/fantoir_annule.html
@@ -1,0 +1,304 @@
+<html>
+<head>
+<meta charset="UTF-8">
+<title>FANTOIRs annulés</title>
+<script src="js/jquery-2.1.1.min.js"></script>
+<script src="js/jquery.tablesorter.min.js"></script>
+<style>
+	body{
+	    font-family: monospace;
+	}
+	#bandeau{
+		top:0px;
+		width:100%;
+		height:150px;
+		z-index:3;
+		position:fixed;
+		background-color:white;
+	}
+	.cellule_intitule{
+		text-align: right;
+	}
+	.cellule_data{
+		font-weight: bold;
+	}
+	#rubriques{
+		position:absolute;
+		top:130px;
+	}
+	#rubriques th{
+		background-color:black;
+		color:white;
+	}
+	#reponse{
+		position:absolute;
+		top:150px;
+		z-index:2;
+	}
+	.emphase{
+		color:red;
+		font-size: x-large;
+	}
+	.rubrique{
+		cursor:pointer;
+		width:200px;
+		height:50px;
+		position:relative;
+		color:black;
+		font-weight: bold;
+		background:white;
+		margin-right:10px;
+	}
+	.rubrique.active{
+		border:3px solid black;
+	}
+	.table_liste{
+		display:none;
+	}
+	.zone_click{
+		cursor:pointer;
+		color:blue;
+		text-decoration: underline;
+	}
+	.zone_click.clicked{
+		background-color:green;
+		color:white;
+	}
+	#refresh_infos{
+		position: fixed;
+		width: 250px;
+		height: 56px;
+		top: 6px;
+		right: 109px;
+		display:none;
+	}
+	#refresh_infos span{
+		font-weight: bold;
+	}
+	#bouton_refresh{
+		position: fixed;
+		background-image: url("img/72176-600.png");
+		background-size: 49px 56px;
+		background-repeat: no-repeat;
+		width: 49px;
+		height: 56px;
+		top: 6px;
+		right: 60px;
+	}
+	#infos_refresh{
+		width:100%;
+		height:200px;
+		top:0px;
+		left:0px;
+		background-color:lightgrey;
+		opacity:0.8;
+		position:fixed;
+		//visibility:hidden;
+		display:none;
+		z-index: 15;
+	}
+	#wait_ajax{
+		position:fixed;
+		z-index:1;
+		width:100%;
+		height:100%;
+		background-color:lightgray;
+		opacity:0;
+		text-align:center;
+	}
+	#wait_ajax span{
+		background-color:black;
+		vertical-align:middle;
+		font-size:30px;
+		line-height:500px;
+		color:white;
+		border:50px solid black;
+	}
+	#infobulle_aide{
+		position: fixed;
+		color: red;
+		background: #dddddd;
+		width: 40px;
+		height: 40px;
+		border-radius: 40px;
+		top: 10px;
+		right: 10px;
+		vertical-align: bottom;
+		text-align: center;
+		font-weight: bolder;
+		font-size: 35px;
+	}
+	#aide{
+		position:fixed;
+		top:5px;
+		right:5px;
+		width:400px;
+		height:100%;
+		background-color:lavender;
+		overflow-y:scroll;
+		visibility:hidden;
+		z-index: 10;
+	}
+	#table_fantoir_annule tr td,
+		background:white;
+		color:black;
+		font-weight: normal;
+	}
+	#pied_de_page{
+		position:relative;
+		width:100%;
+		height:30px;
+		z-index:3;
+	}
+	#credits{
+		background:darkgrey;
+		position:fixed;
+		bottom:0px;
+		width:100%;
+		overflow:visible;
+		z-index:4;
+		text-align: justify;
+	}
+</style>
+<script>
+	var menu_labels
+	var commune_valide = false
+	var osm_state
+	function start(){
+		$('body').css('cursor','progress');
+		$('#wait_ajax').empty()
+						.css('z-index','20')
+						.css('opacity','0.8')
+						.append($('<span>').append('Recherche des FANTOIRs annulés...'));
+		$.ajax({
+			url: "fantoir_annule.py",
+		})
+		.done(function( data ){
+			titre_bandeau = ' codes FANTOIR annulés'
+			if (data.length == 1){
+				titre_bandeau = ' code FANTOIR annulé'
+			}
+			$('#bandeau h1').append(data.length+titre_bandeau)
+			$('#wait_ajax').append($('<span>').append("Ok"));
+
+			$('body').css('cursor','default');
+			$('#wait_ajax').css('z-index','1').css('opacity','0');
+
+			url_map_org_part1 = 'http://www.openstreetmap.org/'
+			url_map_fr_part1 = 'http://tile.openstreetmap.fr/'
+			url_bano_part1 = 'http://tile.openstreetmap.fr/~cquest/leaflet/bano.html'
+			url_edit_part1 = 'http://www.openstreetmap.org/edit?editor='
+			delta = 0.0008
+
+/*			url_listing_fantoir = './liste_brute_fantoir.html#insee='+$('#input_insee')[0].value
+			add_map_link('table_infos_commune',url_listing_fantoir,'FANTOIR')
+			$('#table_infos_commune').append($('<tr>').append($('<td>').addClass('cellule_intitule').append('Données OSM en date du')).append($('<td>').addClass('cellule_data').append(cache_hsnr[2])))
+*/
+			add_header('table_fantoir_annule',true)
+			table = 'table_fantoir_annule'
+			for (l=0;l<data.length;l++){
+				insee = (data[l][0]).substr(0,5)
+				//Fantoir
+				$('#'+table).append($('<tr>').attr('id',data[l][0]).append($('<td>').addClass('cell_fantoir').text(data[l][0])))
+				//Nom OSM
+				$('#'+table+' tr:last').append($('<td>').text(data[l][1]))
+				//Date d'annulation
+				$('#'+table+' tr:last').append($('<td>').text(data[l][5]))
+				//transfert
+				$('#'+table+' tr:last').append($('<td>').text(data[l][4]))
+				lon = data[l][2]
+				lat = data[l][3]
+				if (lon && lat){
+					url_ol_part2 = '?zoom=18&lat='+lat+'&lon='+lon
+					url_hash_coords = '18/'+lat+'/'+lon
+					xleft	= lon-delta
+					xright	= lon+delta
+					ybottom	= lat-delta
+					ytop	= lat+delta
+				//visu
+					add_map_link(table,url_map_org_part1+'#map='+url_hash_coords,'ORG')
+					add_map_link(table,url_map_fr_part1+url_ol_part2,'FR')
+					add_map_link(table,url_bano_part1+'#'+url_hash_coords,'BANO')
+				//JOSM
+					add_josm_link(table,xleft,xright,ybottom,ytop)
+				//ID
+					add_map_link(table,url_edit_part1+'id#map='+url_hash_coords,'ID')
+				//Potlatch
+					add_map_link(table,url_edit_part1+'potlatch2#map='+url_hash_coords,'P2')
+				//Fantoir
+					add_map_link(table,'./index.html#insee='+insee,'Fantoir-OSM '+insee)
+					add_map_link(table,'./liste_brute_fantoir.html#insee='+insee,'Fantoir brut '+insee)
+				}
+			}
+		})
+	};
+	function check_url_for_insee(){
+		pattern_insee = new RegExp('^[0-9][0-9abAB][0-9]{3}$')
+		var res
+		if (window.location.hash){
+			if (window.location.hash.split('insee=')[1]){
+				if (pattern_insee.test(window.location.hash.split('insee=')[1].split('&')[0])){
+					res = window.location.hash.split('insee=')[1].split('&')[0]
+				} else {
+					alert(window.location.hash.split('insee=')[1].split('&')[0]+' n\'est pas un code INSEE de commune\n\nAbandon')
+				}
+			}
+		}
+		return res
+	}
+	function add_map_link(table,href,text){
+		$('#'+table+' tr:last').append($('<td>')
+									.append($('<a>')
+									.attr('href',href)
+									.attr('target','blank')
+									.text(text)))	
+	}
+	function add_josm_link(table,xl,xr,yb,yt){
+		$('#'+table+' tr:last').append($('<td>')
+									.addClass('zone_click')
+									.attr('xleft',xl).attr('xright',xr).attr('ybottom',yb).attr('ytop',yt)
+									.text('JOSM')
+									.click(function(){
+										srcLoadAndZoom = 'http://127.0.0.1:8111/load_and_zoom?left='+xl+'&right='+xr+'&top='+yt+'&bottom='+yb;
+										$('<img>').appendTo($('#josm_target')).attr('src',srcLoadAndZoom);
+										$(this).addClass('clicked');
+									})
+								)
+	}
+	function add_header(table,with_edit_and_map_links){
+		$('#'+table).append($('<tr>').append($('<th>').append('Code FANTOIR')))
+		$('#'+table+' tr').append($('<th>').append('Voie OSM'))
+		$('#'+table+' tr').append($('<th>').append('Date d\'annulation'))
+		$('#'+table+' tr').append($('<th>').append('Avec ou sans transfert'))
+		if (with_edit_and_map_links){
+			$('#'+table+' tr').append($('<th>').attr('colspan','3').append('Cartes'))
+			$('#'+table+' tr').append($('<th>').attr('colspan','3').append('Édition'))
+			$('#'+table+' tr').append($('<th>').attr('colspan','2').append('FANTOIR'))
+		} 
+	}
+
+</script>
+</head>
+<body onload="start()">
+<div id="bandeau">
+<h1></h1>
+<h4>Liste des codes Fantoir trouvés dans OSM et qui ont été annulés d'après le fichier Fantoir officiel.</h4>
+<div id="pied_de_page"></div>
+</div>
+<table id="rubriques">
+	<tr><td class="rubrique" id="rub_adresses_non_match" cible="table_fantoir_annule"></td>
+	</tr>
+</table>
+</div>
+
+<div id="reponse">
+<table id="table_fantoir_annule" class="table_liste_"></table>
+<div id="pied_de_page"></div>
+</div>
+<div id="credits">
+Données OpenStreetMap : © les Contributeurs d'OpenStreetMap  <a href="http://opendatacommons.org/licenses/odbl/">Licence ODbL</a>
+</div>
+<div id="josm_target" style="visibility : hidden"></div>
+<div id="wait_ajax"></div>
+</body>
+</html>

--- a/fantoir_annule.py
+++ b/fantoir_annule.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import cgi
+import cgitb
+import os.path
+import sys
+import json
+
+import db
+
+def get_data(data_type):
+	with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),'sql/{:s}.sql'.format(data_type)),'r') as fq:
+		with db.bano.cursor() as cur:
+			cur.execute(fq.read())
+
+			return cur.fetchall()
+
+data = get_data('fantoir_annule')
+delta = 0.0008
+
+print("Content-Type: application/json\n")
+
+print(json.JSONEncoder().encode(data))

--- a/index.html
+++ b/index.html
@@ -511,7 +511,7 @@
 			add_header('table_adresses_match',true,false,true,true)
 			add_header('table_voies_fantoir_non_match',false,false,false,true)
 			add_header('table_voies_match',true,false,false,true)
-			add_header('table_places_non_match',true,false,true,true)
+			add_header('table_places_non_match',true,false,false,true)
 			add_header('table_places_match',true,true,false,true)
 			add_header('table_OSM_non_match',true,false,false,false)
 			a_data_table = [[voies_fantoir_adresses_non_match,'table_adresses_non_match'],
@@ -535,7 +535,7 @@
 				// Date de creation
 					$('#'+table+' tr:last').append($('<td>').text(data[l][1]))
 				//Nom Fantoir
-					if ((table == 'table_places_non_match'||table == 'table_places_match') && (data[l][8] == 0)){
+					if ((table == 'table_places_non_match'||table == 'table_places_match') && (data[l][7] == 0)){
 						$('#'+table+' tr:last').append($('<td>').append($('<img>').attr('src','img/ld_habite.png').attr('title','Lieu-dit bâti selon FANTOIR')).append($('<span>').text(data[l][2])))
 					} else {
 						$('#'+table+' tr:last').append($('<td>').text(data[l][2]))
@@ -575,10 +575,6 @@
   					    // add_addr_inspector_link(table,$('#input_insee')[0].value,data[l][0],data[l][1])
   					}
 					if ((s==1) && data[l][7]){
-  					    add_josm_addr_link(table,$('#input_insee')[0].value,fantoir,data[l][3],data[l][7])
-  					    // add_addr_inspector_link(table,$('#input_insee')[0].value,data[l][0],data[l][1])
-  					}
-  					if ((s==4) && data[l][7]){
   					    add_josm_addr_link(table,$('#input_insee')[0].value,fantoir,data[l][3],data[l][7])
   					    // add_addr_inspector_link(table,$('#input_insee')[0].value,data[l][0],data[l][1])
   					}

--- a/index.html
+++ b/index.html
@@ -511,7 +511,7 @@
 			add_header('table_adresses_match',true,false,true,true)
 			add_header('table_voies_fantoir_non_match',false,false,false,true)
 			add_header('table_voies_match',true,false,false,true)
-			add_header('table_places_non_match',true,false,false,true)
+			add_header('table_places_non_match',true,false,true,true)
 			add_header('table_places_match',true,true,false,true)
 			add_header('table_OSM_non_match',true,false,false,false)
 			a_data_table = [[voies_fantoir_adresses_non_match,'table_adresses_non_match'],
@@ -535,7 +535,7 @@
 				// Date de creation
 					$('#'+table+' tr:last').append($('<td>').text(data[l][1]))
 				//Nom Fantoir
-					if ((table == 'table_places_non_match'||table == 'table_places_match') && (data[l][7] == 0)){
+					if ((table == 'table_places_non_match'||table == 'table_places_match') && (data[l][8] == 0)){
 						$('#'+table+' tr:last').append($('<td>').append($('<img>').attr('src','img/ld_habite.png').attr('title','Lieu-dit bâti selon FANTOIR')).append($('<span>').text(data[l][2])))
 					} else {
 						$('#'+table+' tr:last').append($('<td>').text(data[l][2]))
@@ -575,6 +575,10 @@
   					    // add_addr_inspector_link(table,$('#input_insee')[0].value,data[l][0],data[l][1])
   					}
 					if ((s==1) && data[l][7]){
+  					    add_josm_addr_link(table,$('#input_insee')[0].value,fantoir,data[l][3],data[l][7])
+  					    // add_addr_inspector_link(table,$('#input_insee')[0].value,data[l][0],data[l][1])
+  					}
+  					if ((s==4) && data[l][7]){
   					    add_josm_addr_link(table,$('#input_insee')[0].value,fantoir,data[l][3],data[l][7])
   					    // add_addr_inspector_link(table,$('#input_insee')[0].value,data[l][0],data[l][1])
   					}
@@ -748,6 +752,10 @@
 		$('#'+table+' tr').append($('<th>').append('Libellé FANTOIR'))
 		if (with_type_osm){
 			$('#'+table+' tr').append($('<th>').append('Type OSM : libellé OSM'))
+		} else if (table=='table_adresses_non_match'){
+			$('#'+table+' tr').append($('<th>').append('Libellé BAN'))
+		} else if (table=='table_places_non_match'){
+			$('#'+table+' tr').append($('<th>').append('Libellé Cadastre'))
 		} else {
 			$('#'+table+' tr').append($('<th>').append('Libellé OSM'))
 		}
@@ -872,7 +880,7 @@
 <div id="pied_de_page"></div>
 </div>
 <div id="credits">
-Données FANTOIR : © 07/2020 Ministère de l'Économie et des Finances (DGFiP) - <a href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Licence LO/OL</a> ||||
+Données FANTOIR : © 11/2020 Ministère de l'Économie et des Finances (DGFiP) - <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence">Licence LO/OL</a> ||||
 Données OpenStreetMap : © les Contributeurs d'OpenStreetMap  <a href="http://opendatacommons.org/licenses/odbl/">Licence ODbL</a> |||| <!-- Icône "refresh" par iconsmind.com (the Noun project) |||| -->
 <a href="https://github.com/osm-fr/osm-vs-fantoir/">Code source et signalement de bugs/problèmes/suggestions.</a>
 </div>

--- a/sql/fantoir_annule.sql
+++ b/sql/fantoir_annule.sql
@@ -1,0 +1,22 @@
+WITH
+f
+AS
+(SELECT  fantoir10,
+         CASE caractere_annul
+             WHEN 'O' THEN 'sans transfert'
+             WHEN 'Q' THEN 'avec transfert'
+         END transfert,
+         to_char(to_date(date_annul,'YYYYDDD'),'YYYY-MM-DD') date_annul
+FROM	fantoir_voie
+where date_annul!='0000000')
+SELECT v.fantoir,
+       v.voie_osm,
+       ST_X(v.geometrie),
+       ST_Y(v.geometrie),
+       transfert,
+       date_annul
+FROM   cumul_voies v
+JOIN   f
+ON  v.fantoir=f.fantoir10
+ORDER BY 1
+

--- a/sql/fantoir_annule.sql
+++ b/sql/fantoir_annule.sql
@@ -13,7 +13,6 @@ SELECT v.fantoir,
        v.voie_osm,
        ST_X(v.geometrie),
        ST_Y(v.geometrie),
-       transfert,
        date_annul
 FROM   cumul_voies v
 JOIN   f

--- a/sql/places_non_rapprochees_insee.sql
+++ b/sql/places_non_rapprochees_insee.sql
@@ -1,12 +1,4 @@
 WITH
-diff_numero_fantoir
-AS
-(SELECT numero,fantoir FROM cumul_adresses WHERE insee_com = '__com__' and source = 'BAN'
-EXCEPT
-SELECT numero,fantoir FROM cumul_adresses WHERE insee_com = '__com__' and source = 'OSM'),
-fantoir_numeros_manquants
-AS
-(SELECT DISTINCT fantoir,count(*) AS a_proposer FROM diff_numero_fantoir GROUP BY 1),
 s
 AS
 (SELECT fantoir,
@@ -35,7 +27,6 @@ SELECT	c.fantoir,
 		st_x(c.geometrie),
 		st_y(c.geometrie),
 		COALESCE(s.id_statut,0),
-		COALESCE(fm.a_proposer,0),
 		c.ld_bati
 FROM	c
 JOIN	fantoir_voie f
@@ -44,7 +35,5 @@ LEFT OUTER JOIN s
 ON	c.fantoir = s.fantoir
 LEFT OUTER JOIN v
 ON	c.fantoir = v.fantoir
-LEFT OUTER JOIN fantoir_numeros_manquants fm
-ON      f.fantoir10 = fm.fantoir
 WHERE v.fantoir IS NULL
-ORDER BY 8 DESC,9,2;
+ORDER BY 7,2;

--- a/sql/places_non_rapprochees_insee.sql
+++ b/sql/places_non_rapprochees_insee.sql
@@ -1,4 +1,12 @@
 WITH
+diff_numero_fantoir
+AS
+(SELECT numero,fantoir FROM cumul_adresses WHERE insee_com = '__com__' and source = 'BAN'
+EXCEPT
+SELECT numero,fantoir FROM cumul_adresses WHERE insee_com = '__com__' and source = 'OSM'),
+fantoir_numeros_manquants
+AS
+(SELECT DISTINCT fantoir,count(*) AS a_proposer FROM diff_numero_fantoir GROUP BY 1),
 s
 AS
 (SELECT fantoir,
@@ -23,10 +31,11 @@ WHERE   insee_com ='__com__')
 SELECT	c.fantoir,
 		to_char(to_date(f.date_creation,'YYYYDDD'),'YYYY-MM-DD'),
 		c.libelle_fantoir,
-		'--',
+		c.libelle_cadastre,
 		st_x(c.geometrie),
 		st_y(c.geometrie),
 		COALESCE(s.id_statut,0),
+		COALESCE(fm.a_proposer,0),
 		c.ld_bati
 FROM	c
 JOIN	fantoir_voie f
@@ -35,5 +44,7 @@ LEFT OUTER JOIN s
 ON	c.fantoir = s.fantoir
 LEFT OUTER JOIN v
 ON	c.fantoir = v.fantoir
+LEFT OUTER JOIN fantoir_numeros_manquants fm
+ON      f.fantoir10 = fm.fantoir
 WHERE v.fantoir IS NULL
-ORDER BY 7,2;
+ORDER BY 8 DESC,9,2;

--- a/sql/places_rapprochees_insee.sql
+++ b/sql/places_rapprochees_insee.sql
@@ -37,6 +37,7 @@ SELECT	c.fantoir,
 		st_x(c.geometrie),
 		st_y(c.geometrie),
 		COALESCE(s.id_statut,0),
+		'',
 		c.ld_bati
 FROM	c
 JOIN	fantoir_voie f

--- a/sql/places_rapprochees_insee.sql
+++ b/sql/places_rapprochees_insee.sql
@@ -37,7 +37,6 @@ SELECT	c.fantoir,
 		st_x(c.geometrie),
 		st_y(c.geometrie),
 		COALESCE(s.id_statut,0),
-		'',
 		c.ld_bati
 FROM	c
 JOIN	fantoir_voie f

--- a/sql/stats_dept.sql
+++ b/sql/stats_dept.sql
@@ -13,6 +13,21 @@ a AS (	SELECT 	insee_com,
 		WHERE	insee_com like '__dept__%'	AND
 				COALESCE(voie_osm,'') != ''
 		GROUP BY insee_com),
+adrOSM AS (	SELECT 	insee_com,
+				count(distinct concat(numero,fantoir,voie_osm)) adresses_OSM
+		FROM 	cumul_adresses
+		WHERE	insee_com like '__dept__%'
+		GROUP BY insee_com),
+adrBAN AS (	SELECT 	insee_com,
+				count(distinct concat(numero,fantoir,voie_autre)) adresses_BAN
+		FROM 	cumul_adresses
+		WHERE	insee_com like '__dept__%'
+		GROUP BY insee_com),
+adrnon AS (	SELECT 	insee_com,
+				count(distinct concat(numero,fantoir,voie_autre)) adresses_non_rapprochees
+		FROM 	cumul_adresses
+		WHERE	insee_com like '__dept__%' AND COALESCE(voie_osm,'') = ''
+		GROUP BY insee_com),
 v AS (	SELECT 	insee_com,
 				count(distinct fantoir) voies_rapprochees
 		FROM 	cumul_voies
@@ -46,17 +61,24 @@ i AS (	SELECT 	r.format_cadastre,
 				r.insee_com, --Code INSEE
 				r.nom_com, --Commune
 				coalesce(a.voies_avec_adresses_rapprochees::integer,0) a, --Voies avec adresses rapprochées (a)
-				coalesce(v.voies_rapprochees::integer,0) b, --Toutes voies rapprochées						(b)
-				coalesce(vl.voies_rapprochees::integer,0) b1, --Voies rapprochées sur lieux-dits			(bl)
-				t.voies_fantoir c, --Voies FANTOIR 															(c)
-				f.voies_fantoir d, --Voies FANTOIR + lieux-dits												(d)
+				coalesce(v.voies_rapprochees::integer,0) b, --Toutes voies rapprochées (b)
+				coalesce(vl.voies_rapprochees::integer,0) b1, --Voies rapprochées sur lieux-dits (bl)
+				t.voies_fantoir c, --Voies FANTOIR (c)
+				f.voies_fantoir d, --Voies FANTOIR + lieux-dits (d)
 				coalesce(((a.voies_avec_adresses_rapprochees*100/t.voies_fantoir))::integer,0), --Pourcentage de rapprochement avec adresses
 				coalesce(((v.voies_rapprochees*100/t.voies_fantoir))::integer,0), --Pourcentage de rapprochement sur voies
-				coalesce(((v.voies_rapprochees*100/f.voies_fantoir))::integer,0) --Pourcentage de rapprochement sur voies+lieux-dits
+				coalesce(((v.voies_rapprochees*100/f.voies_fantoir))::integer,0), --Pourcentage de rapprochement sur voies+lieux-dits
+				coalesce(adrOSM.adresses_OSM::integer,0), --Adresses OSM
+				coalesce(adrBAN.adresses_BAN::integer,0), --Adresses BAN, BAL
+				coalesce(adrnon.adresses_non_rapprochees::integer,0), --Adresses sans voie rapprochée
+				coalesce(((100-adrnon.adresses_non_rapprochees*100/adrBAN.adresses_BAN))::integer,100) --Pourcentage d'adresses avec voie rapprochée
 		FROM	r
-		LEFT OUTER JOIN	v USING (insee_com)
-		LEFT OUTER JOIN	vl USING (insee_com)
+		LEFT OUTER JOIN v USING (insee_com)
+		LEFT OUTER JOIN vl USING (insee_com)
 		LEFT OUTER JOIN a USING (insee_com)
+		LEFT OUTER JOIN adrOSM USING (insee_com)
+		LEFT OUTER JOIN adrBAN USING (insee_com)
+		LEFT OUTER JOIN adrnon USING (insee_com)
 		JOIN 	t USING (insee_com)
 		JOIN 	f USING (insee_com))
 SELECT	i.*,--(((a/c::double precision)*(c-a)) + ((b/c::double precision)*(c-b)) + ((b/d::double precision)* (d-b)))::integer

--- a/sql/voies_adresses_non_rapprochees_insee.sql
+++ b/sql/voies_adresses_non_rapprochees_insee.sql
@@ -10,19 +10,19 @@ AS
 SELECT	f.fantoir10,
 		to_char(to_date(f.date_creation,'YYYYDDD'),'YYYY-MM-DD'),
 		nature_voie||' '||libelle_voie voie,
-		'--',
+		j.voie_autre,
 		st_x(g.geometrie),
 		st_y(g.geometrie),
 		COALESCE(s.id_statut,0),
 		COALESCE(fm.a_proposer,0)
 FROM	fantoir_voie f
-JOIN	(SELECT	fantoir
+JOIN	(SELECT	fantoir,voie_autre
 		FROM	cumul_adresses
 		WHERE	insee_com = '__com__'	AND
 				source = 'BAN'		AND
 				COALESCE(voie_osm,'') = ''
 		EXCEPT
-		SELECT	fantoir
+		SELECT	fantoir,voie_autre
 		FROM	cumul_adresses
 		WHERE	insee_com = '__com__'	AND
 				source = 'OSM') j

--- a/stats_dept.html
+++ b/stats_dept.html
@@ -127,7 +127,7 @@
 <script>
 
 	var menu_labels
-	var a_champs_stats = ['Format','Code INSEE','Commune','Voies avec adresses<br/>rapprochées (a)','Toutes voies<br/>rapprochées (b)...','...dont voies rapprochées sur<br/>lieux-dits FANTOIR','Voies FANTOIR (c)','Voies et lieux-dits<br/>FANTOIR (d)','Pct adresses /<br/>voies FANTOIR (a/c)','Pct voies /<br/>voies FANTOIR (b/c)','Pct voies /<br/>voies et lieux-dits FANTOIR (b/d)','Indice 2020']
+	var a_champs_stats = ['Format','Code INSEE','Commune','Voies avec adresses<br/>rapprochées (a)','Toutes voies<br/>rapprochées (b)...','...dont voies rapprochées sur<br/>lieux-dits FANTOIR','Voies FANTOIR (c)','Voies et lieux-dits<br/>FANTOIR (d)','Voies avec adresses /<br/>voies FANTOIR (a/c)<br/>en %','Voies rapprochées /<br/>voies FANTOIR (b/c)<br/>en %','Voies rapprochées /<br/>voies et lieux-dits FANTOIR (b/d)<br/>en %','Adresses OSM','Adresses BAN','Adresses BAN sans voie rapprochées','Adresse BAN avec voie rapprochée<br/>en %','Indice 2020']
 	function is_valid_dept(d){
 		pattern_dept = new RegExp('^([01]|[3-8])([0-9])$|^2([aAbB]|[1-9])$|^9([0-5]|7[1-4]|76)$')
 		var res
@@ -198,7 +198,7 @@
 						$('#stats_dept tr:last').append($('<td>')
 												.attr('title',(a_champs_stats[d]).replace('<br\/>',' '))
 												.append($('<a>')
-												.attr('href','http://cadastre.openstreetmap.fr/fantoir/#insee='+stats[c][1])
+												.attr('href','./index.html#insee='+stats[c][1])
 												.text(stats[c][1])))	
 					} else {
 						$('#stats_dept tr:last').append($('<td>').attr('title',(a_champs_stats[d]).replace('<br\/>',' ')).append(stats[c][d]))
@@ -235,24 +235,28 @@
 <h2>Read The F(ANTOIR) Manual</h2>
 <h3>Tableau</h3>
 <p>Les en-têtes de colonnes sont cliquables pour trier le tableau.</p>
-<p>Les liens dans la colonne "Code INSEE" amène à la page http://cadastre.openstreetmap.fr/fantoir/ de la commune et s'ouvrent dans le même onglet.</p>
+<p>Les liens dans la colonne "Code INSEE" amène à la page http://bano.openstreetmap.fr/fantoir/ de la commune et s'ouvrent dans le même onglet.</p>
 <p>Pour chaque commune, les chiffres sont issus des données BANO au moment du chargement de la page.</p>
 <h3>Description des colonnes</h3>
 <li>Format</li><p>Format du cadastre de la commune. Information mise à jour chaque jour à minuit.</p>
-<li>Voies avec adresses rapprochées (a)</li><p>Nombre de voies dont le nom existe dans OSM, dont on connaît le code Fantoir, et pour lesquelles on trouve des adresses, dans OSM ou le Cadastre</p>
+<li>Voies avec adresses rapprochées (a)</li><p>Nombre de voies dont le nom existe dans OSM, dont on connaît le code Fantoir, et pour lesquelles on trouve des adresses, dans OSM, dans la <a href="https://adresse.data.gouv.fr/">Base Adresse National ou une base adresse local</a></p>
 <li>Toutes voies rapprochées (b)</li><p>Nombre de voies dont le nom existe dans OSM et dont on connaît le code Fantoir. Le décompte inclut les voies sans adresses.</p>
 <li>Voies FANTOIR (c)</li><p>Nombre de voies non annulées, de type 1 ou 2 sur la commune, dans le Fantoir 2015.</p>
 <li>Voies et lieux-dits FANTOIR (d)</li><p>Nombre de voies non annulées, de type 1, 2 ou 3 (lieux-dits) sur la commune, dans le Fantoir 2015.</p>
-<li>Pct adresses / voies FANTOIR (a/c)</li><p>Pourcentage de voies OSM dont on connaît le code Fantoir, et ayant des adresses, par rapport au nombre de voies de type 1 et 2 au Fantoir</p>
-<li>Pct voies / voies FANTOIR (b/c)</li><p>Pourcentage de voies OSM dont on connaît le code Fantoir, y compris des voies sans adresses, par rapport au nombre de voies de type 1 et 2 au Fantoir</p>
-<li>Pct voies / voies et lieux-dits FANTOIR (b/d)</li><p>Pourcentage de voies OSM dont on connaît le code Fantoir, y compris des voies sans adresses, par rapport au nombre de voies de type 1, 2 ou 3 au Fantoir</p>
+<li>Adresses / voies FANTOIR (a/c) en %</li><p>Pourcentage de voies OSM dont on connaît le code Fantoir, et ayant des adresses, par rapport au nombre de voies de type 1 et 2 au Fantoir</p>
+<li>Voies / voies FANTOIR (b/c) en %</li><p>Pourcentage de voies OSM dont on connaît le code Fantoir, y compris des voies sans adresses, par rapport au nombre de voies de type 1 et 2 au Fantoir</p>
+<li>Voies / voies et lieux-dits FANTOIR (b/d) en %</li><p>Pourcentage de voies OSM dont on connaît le code Fantoir, y compris des voies sans adresses, par rapport au nombre de voies de type 1, 2 ou 3 au Fantoir</p>
+<li>Adresses OSM</li><p>Nombre d'adresses presentes dans OSM sur la commune</p>
+<li>Adresses BAN</li><p>Nombre d'adresses presentes dans la Base Adresse National ou une base adresse local sur la commune</p>
+<li>Adresses BAN sans voie rapprochées</li><p>Nombre d'adresses présentes dans la <a href="https://adresse.data.gouv.fr/">Base Adresse National ou une base adresse local</a> sur la commune dont le nom de rue n'existe pas dans OSM</p>
+<li>Adresse BAN avec voie rapprochée en %</li><p>Pourcentage d'adresses présentes dans la <a href="https://adresse.data.gouv.fr/">Base Adresse National ou une base adresse local</a> dont le nom de rue existe dans OSM</p>
 <li>Indice 2020</li><p>((a/c)*(c-a)) + ((b/c)*(c-b)) + ((b/d)* (d-b))</br>qui qualifie mieux la notion déficitaire que le simple ecart relatif (plus le chiffre est gros, plus y a de boulot)</p>
 <h3>Documentation FANTOIR</h3>
-<p>Elle est visible dans <a href="http://www.collectivites-locales.gouv.fr/files/files/gestion_locale_dgfip/national/FANTOIR_Descriptif.pdf">ce PDF</a></p>
+<p>Elle est visible dans <a href="https://www.collectivites-locales.gouv.fr/files/files/finances_locales/fantoir/Descriptif_FANTOIR_2016.pdf">ce PDF</a></p>
 <div id="pied_de_page"></div>
 </div>
 <div id="credits">
-Données FANTOIR : © 2015 Ministère de l'Économie et des Finances (DGFiP) - <a href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Licence LO/OL</a>
+Données FANTOIR : © 11/2020 Ministère de l'Économie et des Finances (DGFiP) - <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence">Licence LO/OL</a>
 </div>
 </body>
 </html>

--- a/top_adresses_manquantes.html
+++ b/top_adresses_manquantes.html
@@ -126,6 +126,11 @@
 		color:black;
 		font-weight: normal;
 	}
+	#table_OSM_non_match tr td.clicked{
+		background-color:green;
+		color:white;
+		font-weight: normal;
+	}
 	table.tablesorter thead tr .header {
 		height:40px;
 	}

--- a/top_adresses_manquantes.html
+++ b/top_adresses_manquantes.html
@@ -126,7 +126,7 @@
 		color:black;
 		font-weight: normal;
 	}
-	#table_OSM_non_match tr td.clicked{
+	#table_top_adresses tr td.clicked{
 		background-color:green;
 		color:white;
 		font-weight: normal;


### PR DESCRIPTION
Création d'une page avec les codes fantoir annulés.
Case qui passe au vert dans top adresses manquantes après clic comme dans les pages de commune.
Ajout dans stats_dept de stats sur le nombre d'adresses, surtout pour avoir par commune le nombre et le pourcentage d'adresses qui n'ont pas leur nom de rue dans osm.
Ajout du libellé BAN pour les voies adresses non rapprochées.
Ajout du libellé cadastre pour les places non rapprochées.
Ces libellés permettent de faire un copié collé qui simplifie l'ajout de noms de rue ou lieux dits dans OSM.
Ajout des adresses à intégrées pour les places non rapprochées.
Correction de liens.