### PR TITLE
Added OpenSearch

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="css/style.css" type="text/css"/>
 <link rel="stylesheet" href="css/style_pifometre.css" type="text/css"/>
 <link rel="stylesheet" href="css/menu.css" type="text/css"/>
+<link rel="search" type="application/opensearchdescription+xml" title="Pifomètre BANO" href="opensearch.xml" />
 <script>
 	var menu_labels
 	var commune_valide = false

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Pifomètre BANO</ShortName>
+  <Description>Connaître le rapprochement des voies entre OSM et FANTOIR grâce à code INSEE de la commune.</Description>
+  <Image>/favicon.ico</Image>
+  <Language>fr</Language>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Url type="text/html" template="https://bano.openstreetmap.fr/pifometre/#insee={searchTerms}"/>
+  <AdultContent>false</AdultContent>
+</OpenSearchDescription>


### PR DESCRIPTION
Ajout d'OpenSearch, ce qui permettra de l'ajouter comme moteur de recherche à son navigateur et donc d'effectuer une recherche par code INSEE plus rapidement.

Je n'ai choisi de l'appliquer qu'au Pifomètre, mais il est possible de le configurer pour les autres onglets.

- Doc : https://developer.mozilla.org/en-US/docs/Web/OpenSearch
- Déjà existants sur :
  - https://www.openstreetmap.org/
  - https://wiki.openstreetmap.org/