### PR TITLE
Relooking alerte ancienne commune

### DIFF
--- a/css/style_pifometre.css
+++ b/css/style_pifometre.css
@@ -82,7 +82,8 @@
 	z-index:5;
 	visibility:hidden;
 }
-#table_communes_voisines table tr td.lien_commune{
+#table_communes_voisines table tr td.lien_commune,
+.lien_commune {
 	color:blue;
 	text-decoration: underline;
 	cursor: pointer;
@@ -184,7 +185,7 @@
 
 #boutons-filtres {
 	display: inline-block;
-	margin-left: 5%;
+	margin-left: 3%;
 	margin-top: 30px;
 	width: 60%;
 	font-size: 0.9em;
@@ -242,21 +243,67 @@
 	background-color: #FCFFB7 !important;
 }
 
-/*--------------- ALERTE ANCIENNE COMMUNE --------------------*/
+/*--------------------------------------------------------------------*/
+/*-------------------- ALERTE ANCIENNE COMMUNE -----------------------*/
+/*--------------------------------------------------------------------*/
 
-#alerte_commune{
-	position:fixed;
-	width:100%;
-	height: 150px;
-	background:#FFCF6A;
-	overflow-y:scroll;
+#alerte_commune {
 	visibility:hidden;
-	z-index: 10;
+	position:fixed;
+	width:45%;
+	right: 7%;
+	height: 100px;
+	line-height: 90px; /* doit être identique à height pour centrer verticalement */
+	padding: 5px;
+	background:#FFDE6A;
+  border-bottom: 4px #FFBB2D solid;
+  border-radius: 8px;
 }
+@media only screen and (max-width: 1900px) {
+	#alerte_commune {
+		right: 3%;
+		line-height:40px;
+	}
+}
+@media only screen and (max-width: 1700px) {
+	#alerte_commune {
+		width: 40%;
+		right: 1%;
+		line-height:40px;
+	}
+}
+
 #alerte_commune h3{
 	text-align: center;
 }
 
+.fermer-alerte {
+	color: black;
+	float: right;
+	margin-top: 10px;
+	margin-right: 10px;
+	height: 30px;
+	line-height: 30px;
+	width: 30px;
+	text-align: center;
+	font-weight: bold;
+	background: orange;
+  border-radius: 6px;
+	cursor:pointer;
+}
+
+@media only screen and (max-width: 1330px) {
+	#topnav .bouton_nav, #topnav .menu_actif {
+		padding: 8px 6px;
+		font-size: 0.8em;
+	}
+}
+@media only screen and (max-width: 1150px) {
+	#topnav .bouton_nav, #topnav .menu_actif {
+		padding: 8px 6px;
+		font-size: 0.75em;
+	}
+}
 
 /*--------------- Contenu tableau ---------------*/
 

--- a/index.html
+++ b/index.html
@@ -243,13 +243,13 @@
             if (insee_commune_parente){
                 $('#alerte_commune').empty();
                 $('#alerte_commune').css('visibility','visible');
-                $('#alerte_commune').append($('<div>').addClass('fermer').text('X'))
-                $('#alerte_commune > .fermer').click(function(){
+                $('#alerte_commune').append($('<div>').addClass('fermer-alerte').text('X'))
+                $('#alerte_commune > .fermer-alerte').click(function(){
                     $('#alerte_commune').css('visibility','hidden');
                 })
 /*                $('#alerte_commune').append($('<h3>').text(nom_commune+' est une ancienne commune. Elle a été incorporée dans ').append($('<a>').attr('href','#insee='+insee_commune_parente).text(nom_commune_parente+'('+insee_commune_parente+')')))
 */
-                $('#alerte_commune').append($('<h3>').text(nom_commune+' est une ancienne commune. Elle a été incorporée dans ').append($('<span>').text(nom_commune_parente+'('+insee_commune_parente+')')).attr('insee_cible',insee_commune_parente).addClass('lien_commune')
+                $('#alerte_commune').append($('<h3>').text(nom_commune+' est une ancienne commune. Elle a été incorporée dans ').append($('<span>').addClass('lien_commune').text(nom_commune_parente+' ('+insee_commune_parente+')')).attr('insee_cible',insee_commune_parente)
                     .click(function(){
                         location.assign(window.location.href.split('#')[0]+'#insee='+$(this).attr('insee_cible'))
                         start()

--- a/numeros.html
+++ b/numeros.html
@@ -102,7 +102,7 @@
         insee = check_url_for_insee()
         fantoir = check_url_for_fantoir()
         source = check_url_for_source()
-        $('#lien-retour').empty().append($('<a>').attr('href','pifometre.html#insee='+insee).append('<< Retour à la commune'))
+        //$('#lien-retour').empty().append($('<a>').attr('href','pifometre.html#insee='+insee).append('<< Retour à la commune'))
         global_ligne_id = 1000;
 
         $.ajax({
@@ -183,7 +183,7 @@
     </div>
 
     <div id="bandeau">
-        <div id="lien-retour"><a href="blablabla">Retour à la commune</a></div>
+        <!--<div id="lien-retour"><a href="blablabla">Retour à la commune</a></div>-->
     </div>
 
     <div id="reponse">


### PR DESCRIPTION
✔ Page des numéros : Suppression bouton "Retour à la commune"
✔ Relooking à peu près responsif du bandeau d'alerte Ancienne commune (et son bouton fermer)