### PR TITLE
Améliorations page Fantoirs erronés

### DIFF
--- a/css/style_fantoir_errone_annule.css
+++ b/css/style_fantoir_errone_annule.css
@@ -65,21 +65,42 @@ th {
 td {
 	padding:1px 15px;
 }
-table.tablesorter tbody td,
+table.tablesorter tbody td:not(.zone-clic-josm):not(.cell_fantoir),
 table.tablesorter thead th {
 	padding-left: 1.4em !important;
-}
-#table_fantoir_errone tr td,
-#table_fantoir_annule tr td {
-	background:white;
-	color:black;
-	font-weight: normal;
 }
 
 /*--------------- Couleur de ligne au survol -----------------*/
 
 #reponse tr:hover td {
-	background-color: #FCFFB7 !important;
+	background-color: #FCFFB7;
+}
+
+/*--------------- Liens JOSM et Intégration des adresses ---------------*/
+
+/*------ Général ------*/
+.zone-clic-josm,
+.zone-clic-adresses {
+	cursor:pointer;
+	font-weight: bold;
+	text-decoration: underline;
+	text-align: center;
+}
+
+/*------ Couleurs ------*/
+.zone-clic-josm {
+	color:#863602; /* Marron logo JOSM */
+}
+.zone-clic-josm.clicked, #reponse tr:hover td.zone-clic-josm.clicked {
+	background-color:#863602;
+	color: #fff;
+}
+.zone-clic-adresses {
+	color:#D33A8B; /* Rose adresses */
+}
+.zone-clic-adresses.clicked, #reponse tr:hover td.zone-clic-adresses.clicked {
+	background-color:#D33A8B;
+	color: #fff;
 }
 
 /*---------- Première colonne avec codes Fantoir --------------*/
@@ -87,6 +108,11 @@ table.tablesorter thead th {
 .cell_fantoir {
 	font-family: monospace;
 	font-size: 1.3em;
+	background: url("../img/warning.png") no-repeat left 8% top 30%; /* #FFCF6A orange clair */
+	background-size: 20px 20px;
+	padding-left: 2.7em !important;
+	font-weight: bold;
+	color: #FF6600;
 }
 
 /*-----------------------------------------------------------------------*/

--- a/fantoir_errone.html
+++ b/fantoir_errone.html
@@ -47,8 +47,17 @@
 			$('#'+table).append($('<tbody>'))
 			for (l=0;l<data.length;l++){
 				insee = (data[l][0]).substr(0,5)
-				//Fantoir
-				$('#'+table).append($('<tr>').attr('id',data[l][0]).append($('<td>').addClass('cell_fantoir').text(data[l][0])))
+				dept = (data[l][0]).substr(0,2)
+
+				//Dept
+				$('#'+table).append($('<tr>').attr('id',data[l][0]).append($('<td>').text(dept)))
+				//Commune (INSEE)
+				$('#'+table+' tr:last').append($('<td>').text(data[l][4]+' ('+insee+')'))
+
+
+				//Code Fantoir
+				$('#'+table+' tr:last').append($('<td>').addClass('cell_fantoir').text(data[l][0]))
+				/*$('#'+table).append($('<tr>').attr('id',data[l][0]).append($('<td>').addClass('cell_fantoir').text(data[l][0])))*/
 				//Nom OSM
 				$('#'+table+' tr:last').append($('<td>').text(data[l][1]))
 				lon = data[l][2]
@@ -66,8 +75,8 @@
 				//JOSM
 					add_josm_link(table,xleft,xright,ybottom,ytop)
 				//Fantoir
-					add_map_link(table,'./index.html#insee='+insee,'Fantoir-OSM '+insee)
-					add_map_link(table,'./liste_brute_fantoir.html#insee='+insee,'Fantoir brut '+insee)
+					add_map_link(table,'./index.html#insee='+insee,'Pifomètre ('+insee+')')
+					add_map_link(table,'./liste_brute_fantoir.html#insee='+insee,'Fantoir brut ('+insee+')')
 				}
 			}
 
@@ -105,8 +114,7 @@
 									.text(text)))	
 	}
 	function add_josm_link(table,xl,xr,yb,yt){
-		$('#'+table+' tr:last').append($('<td>')
-									.addClass('zone_click')
+		$('#'+table+' tr:last').append($('<td>').addClass('zone-clic-josm')
 									.attr('xleft',xl).attr('xright',xr).attr('ybottom',yb).attr('ytop',yt)
 									.text('JOSM')
 									.click(function(){
@@ -117,16 +125,14 @@
 								)
 	}
 	function add_header(table,with_edit_and_map_links){
-		$('#'+table).append($('<thead>')
-						.append($('<tr>')
-							.append($('<th>').append('Code FANTOIR'))
-						)
-					)
+		$('#'+table).append($('<thead>').append($('<tr>').append($('<th>').append('Dept'))))
+		$('#'+table+' tr').append($('<th>').append('Commune (code Insee)'))
+		$('#'+table+' tr').append($('<th>').append('Code Fantoir erroné'))
 		$('#'+table+' tr').append($('<th>').append('Voie OSM'))
 		if (with_edit_and_map_links){
 			$('#'+table+' tr').append($('<th>').attr('colspan','1').append('Carte'))
 			$('#'+table+' tr').append($('<th>').attr('colspan','1').append('Édition'))
-			$('#'+table+' tr').append($('<th>').attr('colspan','2').append('FANTOIR'))
+			$('#'+table+' tr').append($('<th>').attr('colspan','2').append('Voir la commune sur...'))
 		}
 	}
 


### PR DESCRIPTION
Page Fantoirs erronés :
✔ Les liens JOSM sont réparés visuellement
✔  "Pifomètre" au lieu de "Fantoir-OSM"
✔  Nouvelles colonnes département et nom de la commune 
✔  Mise en valeur visuelle des codes erronés