### PR TITLE
Améliorations page Fantoirs annulés

### DIFF
--- a/fantoir_annule.html
+++ b/fantoir_annule.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>FANTOIRs annulés</title>
+<title>Fantoirs annulés</title>
 <script src="js/jquery-3.6.4.min.js"></script>
 <script src="js/tablesorter/jquery.tablesorter.js"></script>
 <script src="js/jquery.tablesorter.combined.min.js"></script>
@@ -17,15 +17,15 @@
 	function start(){
 		$('body').css('cursor','progress');
 		$('#wait_ajax').css('visibility','visible')
-						.append($('<p>').append('Chargement des FANTOIRs annulés...'))
+						.append($('<p>').append('Chargement des Fantoirs annulés...'))
 						.append($('<p>').append("(oui, c'est long)"));
 		$.ajax({
 			url: "fantoir_annule.py",
 		})
 		.done(function( data ){
-			titre_bandeau = ' codes FANTOIR annulés'
+			titre_bandeau = ' codes Fantoir annulés'
 			if (data.length == 1){
-				titre_bandeau = ' code FANTOIR annulé'
+				titre_bandeau = ' code Fantoir annulé'
 			}
 			$('#bandeau h1').append(data.length+titre_bandeau)
 			$('#wait_ajax').css('visibility','hidden');
@@ -40,16 +40,23 @@
 			delta = 0.0008
 
 /*			url_listing_fantoir = './liste_brute_fantoir.html#insee='+$('#input_insee')[0].value
-			add_map_link('table_infos_commune',url_listing_fantoir,'FANTOIR')
+			add_map_link('table_infos_commune',url_listing_fantoir,'Fantoir')
 			$('#table_infos_commune').append($('<tr>').append($('<td>').addClass('cellule_intitule').append('Données OSM en date du')).append($('<td>').addClass('cellule_data').append(cache_hsnr[2])))
 */
 			add_header('table_fantoir_annule',true)
 			table = 'table_fantoir_annule'
 			$('#'+table).append($('<tbody>'))
 			for (l=0;l<data.length;l++){
+				
 				insee = (data[l][0]).substr(0,5)
+				dept = (data[l][0]).substr(0,2)
+
+				//Dept
+				$('#'+table).append($('<tr>').attr('id',data[l][0]).append($('<td>').text(dept)))
+				//Commune (Insee)
+				$('#'+table+' tr:last').append($('<td>').text('commune'+' ('+insee+')'))
 				//Fantoir
-				$('#'+table).append($('<tr>').attr('id',data[l][0]).append($('<td>').addClass('cell_fantoir').text(data[l][0])))
+				$('#'+table+' tr:last').append($('<td>').addClass('cell_fantoir').text(data[l][0]))
 				//Nom OSM
 				$('#'+table+' tr:last').append($('<td>').text(data[l][1]))
 				//Date d'annulation
@@ -69,8 +76,8 @@
 				//JOSM
 					add_josm_link(table,xleft,xright,ybottom,ytop)
 				//Fantoir
-					add_map_link(table,'./index.html#insee='+insee,'Fantoir-OSM '+insee)
-					add_map_link(table,'./liste_brute_fantoir.html#insee='+insee,'Fantoir brut '+insee)
+					add_map_link(table,'./index.html#insee='+insee,'Pifomètre ('+insee+')')
+					add_map_link(table,'./liste_brute_fantoir.html#insee='+insee,'Fantoir brut ('+insee+')')
 				}
 			}
 
@@ -110,7 +117,7 @@
 	}
 	function add_josm_link(table,xl,xr,yb,yt){
 		$('#'+table+' tr:last').append($('<td>')
-									.addClass('zone_click')
+									.addClass('zone-clic-josm')
 									.attr('xleft',xl).attr('xright',xr).attr('ybottom',yb).attr('ytop',yt)
 									.text('JOSM')
 									.click(function(){
@@ -121,17 +128,15 @@
 								)
 	}
 	function add_header(table,with_edit_and_map_links){
-		$('#'+table).append($('<thead>')
-						.append($('<tr>')
-							.append($('<th>').append('Code FANTOIR'))
-						)
-					)
+		$('#'+table).append($('<thead>').append($('<tr>').append($('<th>').append('Dept'))))
+		$('#'+table+' tr').append($('<th>').append('Commune (code Insee)'))
+		$('#'+table+' tr').append($('<th>').append('Code Fantoir annulé'))
 		$('#'+table+' tr').append($('<th>').append('Voie OSM'))
 		$('#'+table+' tr').append($('<th>').append('Date d\'annulation'))
 		if (with_edit_and_map_links){
 			$('#'+table+' tr').append($('<th>').attr('colspan','1').append('Carte'))
 			$('#'+table+' tr').append($('<th>').attr('colspan','1').append('Édition'))
-			$('#'+table+' tr').append($('<th>').attr('colspan','2').append('FANTOIR'))
+			$('#'+table+' tr').append($('<th>').attr('colspan','2').append('Voir la commune sur...'))
 		} 
 	}
 

--- a/index.html
+++ b/index.html
@@ -324,19 +324,21 @@
                 reset_filtres()
                 $('#table_pifometre').trigger("destroy");
                 $('#table_pifometre').empty()
-                $('#table_pifometre').append($('<thead>').append($('<tr>').append($('<th>').append('Code FANTOIR'))))
+                $('#table_pifometre').append($('<thead>').append($('<tr>').append($('<th>').append('Code Fantoir'))))
                 if (commune_composee == 1){
                     $('#table_pifometre tr').append($('<th>').append('Ancienne commune'))
                 }
-                $('#table_pifometre tr').append($('<th>').append('Libellé TOPO'))
+                $('#table_pifometre tr').append($('<th>').append('Création Fantoir'))
+                $('#table_pifometre tr').append($('<th>').append('Libellé Fantoir'))
                 $('#table_pifometre tr').append($('<th>').append('Libellé OSM'))
                 $('#table_pifometre tr').append($('<th>').append('Libellé BAN ou CADASTRE'))
                 $('#table_pifometre tr').append($('<th>').append('Carte'))
                 $('#table_pifometre tr').append($('<th>').append('Edition'))
-                $('#table_pifometre tr').append($('<th>').append('Statut FANTOIR ').append($('<a>').attr('href','http://wiki.openstreetmap.org/wiki/Contribuer_%C3%A0_la_BANO#Typologie_des_anomalies_FANTOIR').append('(wiki)')))
+                $('#table_pifometre tr').append($('<th>').append('Statut Fantoir ').append($('<a>').attr('href','http://wiki.openstreetmap.org/wiki/Contribuer_%C3%A0_la_BANO#Typologie_des_anomalies_FANTOIR').append('(wiki)')))
                 $('#table_pifometre tr').append($('<th>').attr('colspan','2').addClass('string-none').append('Intégrer les adresses'))
                 $('#table_pifometre tr').append($('<th>').append('Qualifier les adresses'))
                 $('#table_pifometre').append($('<tbody>'))
+
                 tr_id = 1000
                 for (s=0;s<data.length;s++){
                     let [fantoir,
@@ -366,7 +368,7 @@
                     fantoir_affiche = fantoir
                     fantoir_dans_relation = 'ok'
                     if (caractere_annul == 'B'){
-                        fantoir_affiche = 'Voie sans FANTOIR'
+                        fantoir_affiche = 'Voie sans Fantoir'
                         fantoir_dans_relation = 'ko'
                         if (nom_ban != null){
                             nom_topo = nom_ban.toUpperCase()
@@ -376,8 +378,12 @@
                     tr_id+=1
 
                     $('#table_pifometre tbody').append($('<tr>').attr('id',tr_id).append($('<td>').attr('fantoir',fantoir).addClass('cell_fantoir').text(fantoir_affiche)))
+
+                    //Date de création Fantoir 
+                    $('#table_pifometre tr:last').append($('<td>').text(date_creation))
+
                     if (annule == -1){
-                        $('#table_pifometre tr:last td:last').addClass('annule').attr('title','FANTOIR annulé, à remplacer dans OSM')
+                        $('#table_pifometre tr:last td:last').addClass('annule').attr('title','Code Fantoir annulé, à remplacer dans OSM')
                     }
                     //Ajout des classes pour les filtres à chaque ligne
                     if (is_voie) {
@@ -448,7 +454,7 @@
                     } else {
                         $('#table_pifometre tr:last').append($('<td>'))
                     }
-                    //Statut FANTOIR
+                    //Statut Fantoir
                     if (caractere_annul != 'B' && is_osm_hors_fantoir == false){
                         add_statut_fantoir(tr_id,fantoir,statut_voie)
                     } else {
@@ -493,19 +499,6 @@
         })
     };
 
-    function add_header(){
-        $('#table_pifometre').append($('<thead>').append($('<tr>').append($('<th>').append('Code FANTOIR'))))
-        $('#table_pifometre tr').append($('<th>').append('Création TOPO'))
-        $('#table_pifometre tr').append($('<th>').append('Libellé TOPO'))
-        $('#table_pifometre tr').append($('<th>').append('Libellé OSM'))
-        $('#table_pifometre tr').append($('<th>').append('Libellé BAN ou CADASTRE'))
-        $('#table_pifometre tr').append($('<th>').append('Carte'))
-        $('#table_pifometre tr').append($('<th>').append('Edition'))
-        $('#table_pifometre tr').append($('<th>').append('Statut FANTOIR ').append($('<a>').attr('href','http://wiki.openstreetmap.org/wiki/Contribuer_%C3%A0_la_BANO#Typologie_des_anomalies_FANTOIR').append('(wiki)')))
-        $('#table_pifometre tr').append($('<th>').addClass('string-none').append('Intégrer les adresses'))
-        $('#table_pifometre tr').append($('<th>').append('Qualifier les adresses'))
-        $('#table_pifometre').append($('<tbody>'))
-    };
     function check_url_for_insee(){
         pattern_insee = new RegExp('^[0-9][0-9abAB][0-9]{3}$')
         var res
@@ -650,7 +643,7 @@
                             <label class="switch is-rounded is-small">
                             <input type="checkbox" id="check_osm_hors_fantoir" checked>
                             <span class="check is-blue"></span>
-                            <span class="control-label" critere="osm_hors_fantoir">Trouvé dans OSM et inconnu de FANTOIR<span></span></span>
+                            <span class="control-label" critere="osm_hors_fantoir">Trouvé dans OSM et inconnu de Fantoir<span></span></span>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Page Pifomètre : 
✔ Ajout colonne Date de création Fantoir

Page Fantoirs annulés :
✔ Les liens JOSM sont réparés visuellement
✔ "Pifomètre" au lieu de "Fantoir-OSM"
✔ Nouvelles colonnes département et nom de la commune
✔ Mise en valeur visuelle des codes annulés