### PR TITLE
Info sur les localisations absentes des voies Fantoir non rapprochées

### DIFF
--- a/css/style_pifometre.css
+++ b/css/style_pifometre.css
@@ -263,7 +263,7 @@
 	background-color: #FCFFB7; /* jaune clair */
 }
 
-/*--------------- Pastilles, colonne Libelle OSM, correspondant aux filtres ---------------*/
+/*--------------- Pastilles correspondant aux filtres ---------------*/
 
 .pastille-verte, .pastille-orange, .pastille-bleue {
   height: 15px;
@@ -275,6 +275,15 @@
 .pastille-verte {background-color: #48c78e;}
 .pastille-orange {background-color: #f1AC45;}
 .pastille-bleue {background-color: #0457B3;}
+
+/*--------------- Pastilles correspondant aux filtres ---------------*/
+
+.no-loca {
+	text-align: center;
+	padding-left: 0 !important;
+	font-weight: bold;
+	color: grey;
+}
 
 /*--------------- Changement de statut : validation ---------------*/
 

--- a/index.html
+++ b/index.html
@@ -446,13 +446,13 @@
                                         .text('ORG')))
                     }
                     else {
-                        $('#table_pifometre tr:last').append($('<td>'))
+                        $('#table_pifometre tr:last').append($('<td>').addClass('no-loca').attr('title', 'Objet inconnu d\'OSM, de la BAN et du cadastre\ndonc sans localisation connue.').text('?'))
                     }
                         //JOSM
                     if (lon != undefined) {
                         add_josm_link(xmin,xmax,ymin,ymax)
                     } else {
-                        $('#table_pifometre tr:last').append($('<td>'))
+                        $('#table_pifometre tr:last').append($('<td>').addClass('no-loca').attr('title', 'Objet inconnu d\'OSM, de la BAN et du cadastre\ndonc sans localisation connue.').text('?'))
                     }
                     //Statut Fantoir
                     if (caractere_annul != 'B' && is_osm_hors_fantoir == false){


### PR DESCRIPTION
✔ Page Pifo : Ajout d'un "?" avec infobulle d'explication dans les colonnes Carte et Lien JOSM quand les voies non rapprochées en provenance de Fantoir n'ont pas de localisation