### PR TITLE
#344 Fix lien vers Pifomap avec référence INSEE

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
                                .append(' / ')
                                .append($('<a>')
                                    .attr('target','blank')
-                                   .attr('href','pifomap.html?insee='+insee)
+                                   .attr('href','pifomap.html?insee='+code_insee)
                                    .text('Pifomap')
                                )
 


### PR DESCRIPTION
Proposition de correction du bug https://github.com/osm-fr/osm-vs-fantoir/issues/344

L'hyperlien était construit avec la variable "insee" au lieu de "code_insee".