### PR TITLE
top_adresses_manquantes: URL OSM déterministe pour les voies

### DIFF
--- a/sql/top_adresses_manquantes_dept.sql
+++ b/sql/top_adresses_manquantes_dept.sql
@@ -44,7 +44,7 @@ WHERE   rang = 1 AND
 geom
 AS
 (SELECT DISTINCT c.fantoir,
-        FIRST_VALUE(geometrie) OVER(PARTITION BY c.fantoir) geometrie
+        FIRST_VALUE(geometrie) OVER(PARTITION BY c.fantoir ORDER BY c.numero) geometrie
 FROM    bano_adresses c
 JOIN    max
 USING   (fantoir))


### PR DESCRIPTION
Même principe que #339

Voilà que ce ça donne sur voies_recentes_manquantes pour illustrer comment ça aide à passer en revue toutes les voies sans repasser sur une même voie qu'on a sauté. Pour cause de besoin de vérifier sur le terrain le plus souvent.

![bildo](https://github.com/osm-fr/osm-vs-fantoir/assets/2678215/f0583882-2e75-4d79-86ec-803af110d14b)

Sur top_adresses_manquantes les URLs ne sont pas déterministes donc pas possible de faire la même choses.

Voilà donc un patch qui tente faire la même chose que https://github.com/osm-fr/osm-vs-fantoir/commit/177891bcdc8b3730dd95137f4b3255f81be99865

J'ai pas un pifomètre qui tourne en local donc ça n'est pas testé. En tout cas c'est certain que bano_adresses à une colonne numero. Et si tout va bien ORDER BY ça devrait marcher :)