### PR TITLE
correction longueur pifostats

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -490,7 +490,7 @@ hr {
 
 #pifostats {
 	position:fixed;
-	width:39%;
+	width:40%;
 	height: 110px;
 	top:140px;
 	right:1%;
@@ -535,7 +535,7 @@ hr {
 
 .barre_noms_texte, .barre_noms_avec_adresses_texte, .barre_adresses_texte {
 	float: left;
-	width: 45%;
+	width: 46%;
 	color: #444;
 	font-size: 0.75em;
 	line-height: 1em;
@@ -543,7 +543,7 @@ hr {
 
 .barre_noms_tous, .barre_noms_avec_adresses_tous, .barre_adresses_tous { /*Barre orange du total, en fond*/
 	float: left;
-	width: 50%;
+	width: 49%;
 	height: 8px;
 	background-color: #FFCC55; /* orange */
 	border-radius: 2px;
@@ -968,7 +968,7 @@ hr {
 }
 
 #boutons-filtres.pifo {
-	margin-left: 2%;
+	margin-left: 1%;
 	width: 55%;
 }
 #boutons-filtres.page_numeros {
@@ -1013,7 +1013,7 @@ hr {
 
 #descriptif {
 	float: left;
-	margin:0 2%;
+	margin:0 2% 0 1%;
 	width: 50%;
 }
 

--- a/index.html
+++ b/index.html
@@ -242,26 +242,27 @@
             pourcent_noms_osm = nb_noms_osm*100/Math.max(nb_noms_topo,1)
 
             $('#pifostats .barre_noms_texte').text(nb_noms_osm+' noms OSM'+' (soit '+Math.round(pourcent_noms_osm)+'% des '+nb_noms_topo+' noms Topo)')
-            $('#pifostats .barre_noms_osm').attr('aria-valuenow', Math.round(pourcent_noms_osm))
+            $('#pifostats .barre_noms_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_noms_osm)))
 
             $('#pifostats .barre_noms_avec_adresses_texte').text(nb_nom_adr_osm+' noms OSM avec adresses'+' (soit '+Math.round(pourcent_noms_avec_adresses_osm)+'% des '+nb_noms_ban+' noms BAN)')
-            $('#pifostats .barre_noms_avec_adresses_osm').attr('aria-valuenow', Math.round(pourcent_noms_avec_adresses_osm))
+            $('#pifostats .barre_noms_avec_adresses_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_noms_avec_adresses_osm)))
 
             $('#pifostats .barre_adresses_texte').text(nb_adresses_osm+' adresses OSM'+' (soit '+Math.round(pourcent_adresses_osm)+'% des '+nb_adresses_ban+' adresses BAN)')
-            $('#pifostats .barre_adresses_osm').attr('aria-valuenow', Math.round(pourcent_adresses_osm))
+            
+            $('#pifostats .barre_adresses_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_adresses_osm)))
 
 
             $("#pifostats .barre_noms .barre_noms_osm") .stop(true, true)
                                                         .delay(1000)
-                                                        .animate({width: pourcent_noms_osm+'%'}, 1000);
+                                                        .animate({width: Math.min(100, Math.round(pourcent_noms_osm))+'%'}, 1000);
 
             $("#pifostats .barre_noms_avec_adresses .barre_noms_avec_adresses_osm") .stop(true, true)
                                                         .delay(1000)
-                                                        .animate({width: pourcent_noms_avec_adresses_osm+'%'}, 1000);
+                                                        .animate({width: Math.min(100, Math.round(pourcent_noms_avec_adresses_osm))+'%'}, 1000);
 
             $("#pifostats .barre_adresses .barre_adresses_osm") .stop(true, true)
                                                                 .delay(1000)
-                                                                .animate({width: pourcent_adresses_osm+'%'}, 1000);
+                                                                .animate({width: Math.min(100, Math.round(pourcent_adresses_osm))+'%'}, 1000);
             $('#lien_map_noms').attr('href','pifomap.html?ratio=N#map=10/'+lat_commune+'/'+lon_commune)
             $('#lien_map_noms_avec_adresses').attr('href','pifomap.html?ratio=NA#map=10/'+lat_commune+'/'+lon_commune)
             $('#lien_map_adresses').attr('href','pifomap.html?ratio=A#map=10/'+lat_commune+'/'+lon_commune)

--- a/pifomap.html
+++ b/pifomap.html
@@ -385,32 +385,32 @@
             //------------------------------------
             //-------       PIFOSTATS       ------
             //------------------------------------
-
             pourcent_adresses_osm = nb_adresses_osm*100/Math.max(nb_adresses_ban,1)
             pourcent_noms_avec_adresses_osm = nb_nom_adr_osm*100/Math.max(nb_noms_ban,1)
             pourcent_noms_osm = nb_noms_osm*100/Math.max(nb_noms_topo,1)
 
             $('#pifostats .barre_noms_texte').text(nb_noms_osm+' noms OSM'+' (soit '+Math.round(pourcent_noms_osm)+'% des '+nb_noms_topo+' noms Topo)')
-            $('#pifostats .barre_noms_osm').attr('aria-valuenow', Math.round(pourcent_noms_osm))
+            $('#pifostats .barre_noms_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_noms_osm)))
 
             $('#pifostats .barre_noms_avec_adresses_texte').text(nb_nom_adr_osm+' noms OSM avec adresses'+' (soit '+Math.round(pourcent_noms_avec_adresses_osm)+'% des '+nb_noms_ban+' noms BAN)')
-            $('#pifostats .barre_noms_avec_adresses_osm').attr('aria-valuenow', Math.round(pourcent_noms_avec_adresses_osm))
+            $('#pifostats .barre_noms_avec_adresses_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_noms_avec_adresses_osm)))
 
             $('#pifostats .barre_adresses_texte').text(nb_adresses_osm+' adresses OSM'+' (soit '+Math.round(pourcent_adresses_osm)+'% des '+nb_adresses_ban+' adresses BAN)')
-            $('#pifostats .barre_adresses_osm').attr('aria-valuenow', Math.round(pourcent_adresses_osm))
+            
+            $('#pifostats .barre_adresses_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_adresses_osm)))
 
 
             $("#pifostats .barre_noms .barre_noms_osm") .stop(true, true)
                                                         .delay(1000)
-                                                        .animate({width: pourcent_noms_osm+'%'}, 1000);
+                                                        .animate({width: Math.min(100, Math.round(pourcent_noms_osm))+'%'}, 1000);
 
             $("#pifostats .barre_noms_avec_adresses .barre_noms_avec_adresses_osm") .stop(true, true)
                                                         .delay(1000)
-                                                        .animate({width: pourcent_noms_avec_adresses_osm+'%'}, 1000);
+                                                        .animate({width: Math.min(100, Math.round(pourcent_noms_avec_adresses_osm))+'%'}, 1000);
 
             $("#pifostats .barre_adresses .barre_adresses_osm") .stop(true, true)
                                                                 .delay(1000)
-                                                                .animate({width: pourcent_adresses_osm+'%'}, 1000);
+                                                                .animate({width: Math.min(100, Math.round(pourcent_adresses_osm))+'%'}, 1000);
             $('#lien_map_noms').attr('href','pifomap.html?ratio=N#map=10/'+lat_commune+'/'+lon_commune)
             $('#lien_map_noms_avec_adresses').attr('href','pifomap.html?ratio=NA#map=10/'+lat_commune+'/'+lon_commune)
             $('#lien_map_adresses').attr('href','pifomap.html?ratio=A#map=10/'+lat_commune+'/'+lon_commune)


### PR DESCRIPTION
Pifostats :
✔ Correction barres supérieures à 100% qui dépassent
✔ Correction longueur du bloc de stats pour les nombres à 3 chiffres