### PR TITLE
top_adresses_manquantes: Ajout coordonnées voie dans lien pifomap

### DIFF
--- a/top_adresses_manquantes.html
+++ b/top_adresses_manquantes.html
@@ -132,7 +132,7 @@
                     }
                     //Fantoir
                     add_map_link(table,'./index.html?insee='+insee,'Pifomètre')
-                    add_map_link(table,'./pifomap.html?insee='+insee,'Pifomap')
+                    add_map_link(table,'./pifomap.html?insee='+insee+'#map='+url_hash_coords,'Pifomap')
                     add_map_link(table,'./liste_brute_fantoir.html?insee='+insee,'Topo')
                     add_josm_addr_link(table,insee,nom_com,fantoir,voie,nbaddr,fantoir_dans_relation,is_place)
                 }


### PR DESCRIPTION
Pour que ça centre sur la voie sinon ça tombe juste sur la commune.

Closes  #376

Fait via éditeur en ligne, pas pu tester.

Suite du travail fait dans 6ad28215ebbe9346cabec568e81dbeafd782386f qui par chance a ajouté le lien de base. C'était ce dont je n'était pas sûr comment faire quand j'avais regardé il y a quelques mois.