### PR TITLE
Correction balise html sur la page principale

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="fr">
 <head>
 <meta charset="UTF-8">
 <title>Pifomètre</title>
@@ -550,8 +551,8 @@
     <div id="barre-jaune">
         <span>Commune :</span>
         <form action="javascript:requete_pifometre()" autocomplete="on">
-            <input type="text" id="input_insee" placeholder="Code INSEE"></input>
-            <input type="submit" value="Lister">
+            <input type="text" id="input_insee" placeholder="Code INSEE"/>
+            <input type="submit" value="Lister"/>
         </form>
     </div>
 
@@ -629,13 +630,13 @@
                     <ul>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_voie" checked>
+                            <input type="checkbox" id="check_voie" checked/>
                             <span class="check is-dark"></span>
                             <span class="control-label" critere="voie">Voies<span></span></span>
                         </li>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_lieu_dit" checked>
+                            <input type="checkbox" id="check_lieu_dit" checked/>
                             <span class="check is-dark"></span>
                             <span class="control-label" critere="lieu_dit">Lieux-dits<span></span></span>
                         </li>
@@ -645,13 +646,13 @@
                     <ul>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_nom_integre" checked>
+                            <input type="checkbox" id="check_nom_integre" checked/>
                             <span class="check is-green"></span>
                             <span class="control-label" critere="nom_integre">Déjà rapprochés dans OSM<span></span></span>
                         </li>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_nom_a_integrer" checked>
+                            <input type="checkbox" id="check_nom_a_integrer" checked/>
                             <span class="check is-orange"></span>
                             <span class="control-label" critere="nom_a_integrer">Pas encore rapprochés dans OSM<span></span></span>
                         </li>
@@ -661,13 +662,13 @@
                     <ul>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_avec_adresses" checked>
+                            <input type="checkbox" id="check_avec_adresses" checked/>
                             <span class="check is-pink"></span>
                             <span class="control-label" critere="avec_adresses">Ayant des adresses référencées dans la BAN<span></span></span>
                         </li>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_sans_adresses" checked>
+                            <input type="checkbox" id="check_sans_adresses" checked/>
                             <span class="check is-dark"></span>
                             <span class="control-label" critere="sans_adresses">Sans adresses<span></span></span>
                         </li>
@@ -679,7 +680,7 @@
                     <ul>
                         <li>
                             <label class="switch is-rounded is-small">
-                            <input type="checkbox" id="check_osm_hors_fantoir" checked>
+                            <input type="checkbox" id="check_osm_hors_fantoir" checked/>
                             <span class="check is-blue"></span>
                             <span class="control-label" critere="osm_hors_fantoir">Trouvé dans OSM et inconnu du fichier Topo<span></span></span>
                         </li>


### PR DESCRIPTION
Cette PR:
- Ajoute la balise `<!DOCTYPE html>`
- Ajoute la propriété `lang="fr"`
- Ferme les balises input