### PR TITLE
Revert des changes sur la balise label

### DIFF
--- a/pifomap.html
+++ b/pifomap.html
@@ -613,13 +613,13 @@
                 <div>
                     <ul>
                         <li>
-                            <label class="switch is-rounded is-small"></label>
+                            <label class="switch is-rounded is-small">
                             <input type="checkbox" id="check_voie"  critere="voie" checked/>
                             <span class="check is-dark"></span>
                             <span class="control-label">Voies<span></span></span>
                         </li>
                         <li>
-                            <label class="switch is-rounded is-small"></label>
+                            <label class="switch is-rounded is-small">
                             <input type="checkbox" id="check_lieudit"  critere="lieudit" checked/>
                             <span class="check is-dark"></span>
                             <span class="control-label">Lieux-dits<span></span></span>
@@ -629,13 +629,13 @@
                 <div>
                     <ul>
                         <li>
-                            <label class="switch is-rounded is-small"></label>
+                            <label class="switch is-rounded is-small">
                             <input type="checkbox" id="check_rapproches" critere="rapproches" checked/>
                             <span class="check is-green"></span>
                             <span class="control-label">Déjà rapprochés dans OSM<span></span></span>
                         </li>
                         <li>
-                            <label class="switch is-rounded is-small"></label>
+                            <label class="switch is-rounded is-small">
                             <input type="checkbox" id="check_non_rapproches"  critere="non_rapproches" checked/>
                             <span class="check is-orange"></span>
                             <span class="control-label">Pas encore rapprochés dans OSM<span></span></span>


### PR DESCRIPTION
Cette PR finit de corriger le commit https://github.com/osm-fr/osm-vs-fantoir/commit/6c34f6dbbeb60570a5950fc6c6ab16cb2a4e304a

A mon sens dans cette situation, il n'est pas possible de fermer la balise label si on veut que le style s'applique au bouton.
A voir pour spécifier la classe sur l'input et utiliser un for dans le label pour afficher le texte ?