### PR TITLE
Corrections html sur la page pifodrome

### DIFF
--- a/pifodrome.html
+++ b/pifodrome.html
@@ -53,7 +53,7 @@
                             <label class="switch is-rounded is-small">
                             <input type="checkbox" id="check_petits_dep"  critere="petits_dep" checked/>
                             <span class="check is-pink"></span>
-                            <span class="control-label">Petits dépassements (< 1m)</span>
+                            <span class="control-label">Petits dépassements (&lt; 1m)</span>
                         </li>
                         <li>
                             <label class="switch is-rounded is-small">
@@ -65,14 +65,14 @@
                 </div>
             </div>
             <div class="zone-boutons-themes">
-                <button id="bouton_theme_route_de" title="Affiches les voies dont le nom contient &#10celui de l'une des communes traversées">Les<br/>Routes de...</button>
+                <button id="bouton_theme_route_de" title="Affiches les voies dont le nom contient &#10;celui de l'une des communes traversées">Les<br/>Routes de...</button>
             </div>
         </div>
 
         <div id="descriptif">
             <h1>Pifodrome : la carte des voies à cheval</h1>
             <h3>Cette carte montre toutes les routes et rues nommées (ayant un tag <span class="monospace">name</span>) croisant au moins une limite administrative<span class="only_desktop">, donc débordant sur au moins 2 communes. Il faudrait couper la voie au niveau de la frontière, et vérifier son nom de chaque côté</span>.</h3>
-            <div class="encadre_aide only_mobile">La carte des voies à cheval n'est pas adaptée à un usage mobile.</a></div>
+            <div class="encadre_aide only_mobile">La carte des voies à cheval n'est pas adaptée à un usage mobile.</div>
             <div class="encadre_aide"><a href="aide/pifodrome.html" target="_blank">Aide : Comment corriger les voies à cheval ?</a></div>
         </div>
     </div>


### PR DESCRIPTION
- Remplacement du caractère `<` par `&lt;`
- Ajout d'un point virgule manquant
- Suppression d'une balise </a> orpheline