### PR TITLE
Correction fullname BAN

### DIFF
--- a/pifometre/aide.html
+++ b/pifometre/aide.html
@@ -37,22 +37,22 @@
 
 	<p><span class="titre_para">Voies et lieux-dits</span> Pour choisir d'afficher uniquement les voies, ou uniquement les lieux-dits, ou les deux.</p>
 	<p><span class="titre_para">Rapprochement</span>
-	<br/>• Le filtre vert permet d'afficher ou non les voies/lieux-dits provenant du fichier Topo (ex Fantoir), de la <abbr title="Base Adresses Nationale">BAN</abbr> ou du Cadastre et ayant trouvé une correspondance (par leur nom ou leur code Fantoir) avec un endroit dans OSM.
-	<br/>• Le filtre orange permet d'afficher ou non les voies/lieux-dits provenant du fichier Topo (ex Fantoir), de la <abbr title="Base Adresses Nationale">BAN</abbr> ou du Cadastre et n'ayant pas trouvé d'endroit correspondant dans OSM.</p>
+	<br/>• Le filtre vert permet d'afficher ou non les voies/lieux-dits provenant du fichier Topo (ex Fantoir), de la <abbr title="Base Adresse Nationale">BAN</abbr> ou du Cadastre et ayant trouvé une correspondance (par leur nom ou leur code Fantoir) avec un endroit dans OSM.
+	<br/>• Le filtre orange permet d'afficher ou non les voies/lieux-dits provenant du fichier Topo (ex Fantoir), de la <abbr title="Base Adresse Nationale">BAN</abbr> ou du Cadastre et n'ayant pas trouvé d'endroit correspondant dans OSM.</p>
 
 	<p><span class="titre_para">Filtre bleu</span> Apparaissent ici les lieux «trouvés dans OSM et inconnus du fichier Topo (ex Fantoir)». Cette liste remonte les noms d'endroits (rues, lieux-dits, cimetières, écoles, parkings...) qui pourraient avoir une correspondance dans le fichier Topo mais qui n'en ont pas trouvé – soit parce qu'il n'y a rien de correspondant dans le Topo de la commune, soit parce qu'il y a une erreur à identifier et corriger dans OSM (orthographe...).</p>
 
 	<p><span class="titre_para">Adresses</span>
-	<br/>• Le filtre rose permet d'afficher ou non les voies/lieux-dits ayant des adresses référencées dans la <abbr title="Base Adresses Nationale">BAN</abbr>.
-	<br/>• Le filtre gris permet d'afficher ou non les voies/lieux-dits n'ayant pas d'adresses référencées dans la <abbr title="Base Adresses Nationale">BAN</abbr>.</p>
+	<br/>• Le filtre rose permet d'afficher ou non les voies/lieux-dits ayant des adresses référencées dans la <abbr title="Base Adresse Nationale">BAN</abbr>.
+	<br/>• Le filtre gris permet d'afficher ou non les voies/lieux-dits n'ayant pas d'adresses référencées dans la <abbr title="Base Adresse Nationale">BAN</abbr>.</p>
 
 	<h3>4. Les statistiques</h3>
 	<p><img src="img/aide/aide_pifo_stats.png"/></p>
 
 	<p>Pour la commune chargée, les stats montrent l'avancement de :</p>
 	<p><span class="titre_para">• l'intégration des noms de voies et lieux-dits</span> : rapport du nombre de voies et lieux-dits avec un <span class="monospace">name</span> présents sur OSM par rapport au nombre de noms présents dans le fichier Topo (ex-Fantoir).</p>
-	<p><span class="titre_para">• l'intégration des noms de voies et lieux-dits comportant des adresses</span> : rapport du nombre de nombre de voies et lieux-dits avec un <span class="monospace">name</span> présents sur OSM par rapport au nombre de noms liés à des adresses recensées par la <abbr title="Base Adresses Nationale">BAN</abbr>.</p>
-	<p><span class="titre_para">• l'intégration des adresses</span> : rapport du nombre de numéros d'adresse présents sur OSM par rapport au nombre recensé par la <abbr title="Base Adresses Nationale">BAN</abbr>.</p>
+	<p><span class="titre_para">• l'intégration des noms de voies et lieux-dits comportant des adresses</span> : rapport du nombre de nombre de voies et lieux-dits avec un <span class="monospace">name</span> présents sur OSM par rapport au nombre de noms liés à des adresses recensées par la <abbr title="Base Adresse Nationale">BAN</abbr>.</p>
+	<p><span class="titre_para">• l'intégration des adresses</span> : rapport du nombre de numéros d'adresse présents sur OSM par rapport au nombre recensé par la <abbr title="Base Adresse Nationale">BAN</abbr>.</p>
 
 	<h3>Les boutons</h3>
 	<p><img src="img/aide/aide_pifo_boutons.png"/></p>
@@ -79,7 +79,7 @@
 	<br/>Si aucun nom dans OSM ne correspond à la voie ou au lieu-dit trouvé dans Topo, s'affiche juste une pastille orange en forme de losange.
 	</p>
 
-	<p><span class="titre_para">9. Libellé <abbr title="Base Adresses Nationale">BAN</abbr> ou Cadastre.</span> Nom trouvé dans la <abbr title="Base Adresses Nationale">BAN</abbr> pour les voies, ou dans le Cadastre pour les lieux-dits. La source est précisée sur chaque ligne avec un pictogramme <img src="img/ban_logo.png" height="16px"/> BAN ou <img src="img/cadastre.png"/> Cadastre.</p>
+	<p><span class="titre_para">9. Libellé <abbr title="Base Adresse Nationale">BAN</abbr> ou Cadastre.</span> Nom trouvé dans la <abbr title="Base Adresse Nationale">BAN</abbr> pour les voies, ou dans le Cadastre pour les lieux-dits. La source est précisée sur chaque ligne avec un pictogramme <img src="img/ban_logo.png" height="16px"/> BAN ou <img src="img/cadastre.png"/> Cadastre.</p>
 
 	<p><span class="titre_para">10. Carte.</span> Lien vers la carte Openstreetmap.org, et vers la page Pifomap de la commune – centrés sur la voie ou le lieu-dit sélectionné·e.</p>
 
@@ -87,11 +87,11 @@
 
 	<p><span class="titre_para">12. Statut du nom.</span> Liste des «anomalies» que peut comporter une voie ou un lieu-dit venant du fichier Topo. Statut attribué à chaque voie ou lieu-dit disposant d'un code Fantoir, pour indiquer un éventuel problème empêchant ou non le rapprochement avec OSM. </p>
 
-	<p><span class="titre_para">13. Intégrer les adresses.</span> Liens permettant d'intégrer dans OpenStreetMap les adresses affectées à cette voie ou ce lieu-dit selon la <abbr title="Base Adresses Nationale">BAN</abbr>. Le nombre affiché correspond au nombre de numéros d'adresses recensés par la <abbr title="Base Adresses Nationale">BAN</abbr> et non encore présents dans OSM.
+	<p><span class="titre_para">13. Intégrer les adresses.</span> Liens permettant d'intégrer dans OpenStreetMap les adresses affectées à cette voie ou ce lieu-dit selon la <abbr title="Base Adresse Nationale">BAN</abbr>. Le nombre affiché correspond au nombre de numéros d'adresses recensés par la <abbr title="Base Adresse Nationale">BAN</abbr> et non encore présents dans OSM.
 	<br/>Cliquer sur le lien ouvre un nouveau calque sur <abbr title="le logiciel JOSM">JOSM</abbr>, comportant lesdites adresses soit sous forme de points (<span class="monospace">addr:housenumber</span> et <span class="monospace">addr:street</span> ou <span class="monospace">addr:place</span>) soit par relation <span class="monospace">associatedStreet</span>.
-	<br/>Si toutes les adresses recensées par la <abbr title="Base Adresses Nationale">BAN</abbr> sont déjà existantes dans OSM, cette colonne affiche «✔ Adresses intégrées».</p>
+	<br/>Si toutes les adresses recensées par la <abbr title="Base Adresse Nationale">BAN</abbr> sont déjà existantes dans OSM, cette colonne affiche «✔ Adresses intégrées».</p>
 
-	<p><span class="titre_para">14. Qualifier les adresses.</span> Liens vers la page de qualification des adresses. Cette page affiche une carte de la voie ou du lieu-dit, avec les adresses déjà présentes dans OSM, les adresses venant de la <abbr title="Base Adresses Nationale">BAN</abbr> pas encore intégrées dans OSM, et un tableau listant les adresses et leurs anomalies éventuelles (sur le même modèle que les «statuts du nom».
+	<p><span class="titre_para">14. Qualifier les adresses.</span> Liens vers la page de qualification des adresses. Cette page affiche une carte de la voie ou du lieu-dit, avec les adresses déjà présentes dans OSM, les adresses venant de la <abbr title="Base Adresse Nationale">BAN</abbr> pas encore intégrées dans OSM, et un tableau listant les adresses et leurs anomalies éventuelles (sur le même modèle que les «statuts du nom».
 
 	<p>&nbsp;</p>
 

--- a/pifometre/aide/pifodrome.html
+++ b/pifometre/aide/pifodrome.html
@@ -7,7 +7,7 @@
 	<script src="../js/jquery-3.6.4.min.js"></script>
 	<script src="../js/fonctions.js"></script>
 	<script defer src="../js/menu.js"></script>
-	
+
     <link rel="icon" type="image/png" href="../img/logo/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="../img/logo/favicon.svg" />
     <link rel="shortcut icon" href="../img/logo/favicon.ico" />
@@ -32,7 +32,7 @@
 			<p>Exemple ci-dessous : la Route de Lutzelbourg, majoritairement située sur la commune de Hultehouse, déborde sur la commune de Lutzelbourg.</p>
 			<p><img class="capture" src="../img/aide/aide_pifodrome_exemple.jpg"/></p>
 			<p><em>Il faut cliquer sur la voie pour afficher ses informations dans le panneau de gauche.</em></p>
-			<p><img class="picto" src="../img/aide/vac_rond_vert.png"/><strong>Rond vert</strong> : extrémité dans une commune où la voie est rapprochée – c'est-à-dire que son nom existe à la fois dans OSM et dans le fichier Topo ou la <abbr title="Base Adresses Nationale">BAN</abbr> de la commune.</p>
+			<p><img class="picto" src="../img/aide/vac_rond_vert.png"/><strong>Rond vert</strong> : extrémité dans une commune où la voie est rapprochée – c'est-à-dire que son nom existe à la fois dans OSM et dans le fichier Topo ou la <abbr title="Base Adresse Nationale">BAN</abbr> de la commune.</p>
 	        <p><img class="picto" src="../img/aide/vac_rond_rouge.png"/><strong>Rond rouge</strong> : extrémité dans une commune où la voie n'est pas rapprochée.</p>
 	        <p><img class="picto" src="../img/aide/vac_limite.png"/><strong>Frontière</strong> : marque un franchissement de limite administrative.</p>
 		</div>

--- a/pifometre/pifomap.html
+++ b/pifometre/pifomap.html
@@ -53,12 +53,12 @@
         insee=check_url_for_insee()
 
         $('#bouton_pifoprogression').click(function(){
-            if (!$(this).hasClass('onglet_actif')) { 
+            if (!$(this).hasClass('onglet_actif')) {
                 $(this).addClass('onglet_actif')
                 $('#bouton_pifostats').removeClass('onglet_actif');
                 $('#pifostats').css('visibility','hidden');
                 $('#bouton_pifofiltres').removeClass('onglet_actif');
-                $('#pifofiltres').css('visibility','hidden');              
+                $('#pifofiltres').css('visibility','hidden');
                 $('#pifoprogression').css('visibility','visible');
             }
         })
@@ -130,7 +130,7 @@
         $('#bouton_localise_moi').click(function(){
                                 $('body').css('cursor','progress');
                                 $('#wait_ajax').empty()
-                                               .css('visibility','visible') 
+                                               .css('visibility','visible')
                                                .append($('<span>').append('Localisation en cours...'));
                                 getLocation();
                             })
@@ -155,7 +155,7 @@
         }
         $('body').css('cursor','progress');
         $('#wait_ajax').empty()
-                       .css('visibility','visible') 
+                       .css('visibility','visible')
                        .append($('<span>').append('Mise à jour BANO en cours...'));
         $('#wait_ajax_mobile').css('visibility','visible');
         $.ajax({
@@ -238,7 +238,7 @@
         min_lat = 90
         max_lat = -90
         $('#wait_ajax').empty()
-                       .css('visibility','visible') 
+                       .css('visibility','visible')
                        .append($('<span>').append('Chargement...'));
         $('#wait_ajax_mobile').css('visibility','visible');
         $.ajax({
@@ -281,7 +281,7 @@
                     poly] = polydata[s]
                 if (poly.type == 'Polygon'){
                     res.features.push(get_geojson_poly(poly,{'fantoir':get_fantoir_affiche(fantoir),'nom':nom_ban,'statut':label_statut}))
-                } 
+                }
             }
             map.getSource('polygones_convexhull').setData(res)
 
@@ -527,7 +527,7 @@
             $('#pifostats .barre_noms_avec_adresses_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_noms_avec_adresses_osm)))
 
             $('#pifostats .barre_adresses_texte').text(nb_adresses_osm+' adresses OSM'+' (soit '+Math.round(pourcent_adresses_osm)+'% des '+nb_adresses_ban+' adresses BAN)')
-            
+
             $('#pifostats .barre_adresses_osm').attr('aria-valuenow', Math.min(100, Math.round(pourcent_adresses_osm)))
 
 
@@ -649,22 +649,22 @@
         <div id="pifostats" class="pifomap">
             <div><h3>Intégration des voies et adresses de la commune</h3></div>
 
-            <div class="barre_noms"> 
-                <div class="barre_noms_texte"></div> 
+            <div class="barre_noms">
+                <div class="barre_noms_texte"></div>
                 <div class="barre_noms_tous" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuetext="" aria-valuemax="100">
                     <div class="barre_noms_osm"></div>
                 </div>
             </div>
 
-            <div class="barre_noms_avec_adresses"> 
-                <div class="barre_noms_avec_adresses_texte"></div> 
+            <div class="barre_noms_avec_adresses">
+                <div class="barre_noms_avec_adresses_texte"></div>
                 <div class="barre_noms_avec_adresses_tous" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuetext="" aria-valuemax="100">
                     <div class="barre_noms_avec_adresses_osm"></div>
                 </div>
            </div>
 
-            <div class="barre_adresses"> 
-                <div class="barre_adresses_texte"></div> 
+            <div class="barre_adresses">
+                <div class="barre_adresses_texte"></div>
                 <div class="barre_adresses_tous" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuetext="" aria-valuemax="100">
                     <div class="barre_adresses_osm"></div>
                 </div>
@@ -791,7 +791,7 @@
         </tr>
         </table>
         <p><span class="petit">Ce rapport correspond à :<br/>- nombre de noms de voies présentes sur OSM / Nombre de noms de voies recensés dans le fichier Topo
-            <br/>- nombre d'adresses présentes sur OSM / Nombre d'adresses recensées par la <abbr title="Base Adresses Nationale">BAN</abbr></span></p>
+            <br/>- nombre d'adresses présentes sur OSM / Nombre d'adresses recensées par la <abbr title="Base Adresse Nationale">BAN</abbr></span></p>
     </div>
 
     <footer>


### PR DESCRIPTION
Il semble que la BAN n'ai pas de `s` à `Adresse`, je n'ai pas modifié pour BANO puisqu'`Adresses` à bien un `s` sur le wiki.
Source:
- https://api.gouv.fr/les-api/base-adresse-nationale
- https://fr.wikipedia.org/wiki/Base_adresse_nationale
- https://wiki.openstreetmap.org/wiki/FR:France/Base_Adresses_Nationale_Ouverte_(BANO)