### PR TITLE
fix images éditeurs dans Pifomètre

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1901,13 +1901,24 @@ table tr.static td {
 #pifomap_table_liens .zone-clic-id a {
 	width: 100%;
 }
-.zone-clic-josm {
-	background: url('../img/logo_josm.png') no-repeat left 50% top 50%;
+.zone-clic-josm, .zone-clic-id {
+	position: relative;	
+}
+.zone-clic-id a::before, .zone-clic-josm::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%; 
+}
+.zone-clic-id a::before {
+	background: url('../img/logo_id.png') no-repeat left 50% top 50%;
 	background-size: 20px;
 }
-.zone-clic-id {
-	background: url('../img/logo_id.png') no-repeat left 50% top 50%;
-	background-size: 20px;	
+.zone-clic-josm::before {
+	background: url('../img/logo_josm.png') no-repeat left 50% top 50%;
+	background-size: 20px;
 }
 /*-- Cellules fusionnées pour adresses déjà intégrées --*/
 .zone-adresses {


### PR DESCRIPTION
Retour de l'image JOSM et iD dans Pifomètre sur les lignes grisées à statut Fantoir non "ok"