### PR TITLE
Identification du code INSEE à partir du libellé de la commune

### DIFF
--- a/pifometre/index.html
+++ b/pifometre/index.html
@@ -35,6 +35,8 @@
 
     RAZ_FILTRES = true
 
+    NB_SUGGESTIONS_MAX = 30
+
     affichage_pagine = false
 
     var table_data
@@ -766,6 +768,54 @@
                             .append($('<span>').append(osm_state+' (UTC)'))
                             .css('visibility','visible');
     }
+    function recupere_code_insee(v) {
+    const dropdown = $('#insee_liste');
+    if (v.length < 3) {
+        dropdown.empty(); // Vider la liste existante
+        dropdown.append('<option value="">Sélectionnez une commune</option>');
+        return;
+    }
+    v = v.toLowerCase();
+    console.log(v)
+    let url_to_call = ''
+    if (/^[0-9]*[ab]?[0-9]*$/.test(v)) {
+        // Si la valeur est compatible avec un code INSEE, on ne fait pas de requête AJAX
+        return
+    } else {
+        //on suppose que c'est un début de nom de commune
+        url_to_call = 'https://geo.api.gouv.fr/communes?fields=code&fields=nom&nom=' + encodeURIComponent(v)
+    }
+    $.ajax({
+        url: url_to_call, // URL du script côté serveur
+        method: 'GET',
+        success: function(data) {
+            dropdown.empty(); // Vider la liste existante
+            console.log("nb rep", data.length)
+            if (data.length == 0) {
+                dropdown.append('<option value="">Aucune commune trouvée</option>');
+            } else {
+                dropdown.append('<option value="">Sélectionnez une option</option>');
+
+                // Ajouter les nouvelles options
+                var data_affichage = data.slice(0,NB_SUGGESTIONS_MAX)
+                console.log("nb rep aff", data_affichage.length)
+                data_affichage.forEach(option => {
+                    dropdown.append(`<option value="${option.code}">${option.code}:${option.nom}</option`);
+                });
+                if (data.length > NB_SUGGESTIONS_MAX) {
+
+                    dropdown.append('<option value=""> '+v+' (liste tronquée) </option>');
+                    console.log(data.length, v)
+                }
+            }
+        },
+        error: function() {
+            alert('Erreur lors du chargement des options.');
+        }
+    });
+
+    }
+
 </script>
 </head>
 
@@ -776,8 +826,9 @@
 
     <div id="barre-jaune">
         <span>Commune :</span>
-        <form action="javascript:requete_pifometre()" autocomplete="on">
-            <input type="text" id="input_insee" placeholder="Code INSEE"/>
+        <form action="javascript:requete_pifometre()" autocomplete="off">
+            <input type="text" size=25 list="insee_liste" id="input_insee" placeholder="Nom Commune ou Code INSEE" oninput="recupere_code_insee(this.value)"/>
+            <datalist id="insee_liste"></datalist>
             <input type="submit" value="Lister"/>
         </form>
     </div>


### PR DESCRIPTION
Bonjour

reprise de contact après un temps de mise en veille assez important.

la boîte de saisie de la page d'accueil de pifomètre va permettre maintenant de retrouver le code Insee à partir d'un morceau d'un bout du libellé de la commune. Utilisation de l'API geo.api.gouv.fr/communes en attendant de trouver mieux ...