### PR TITLE
Nettoyage des suffixes

### DIFF
--- a/pifometre/numeros.html
+++ b/pifometre/numeros.html
@@ -316,7 +316,7 @@
                                         json_resp = {}
                                         numero_int = parseInt(numero)
                                         if (numero != numero_int){
-                                            json_resp['suffixe'] = numero.slice(numero_int.toString().length)
+                                            json_resp['suffixe'] = numero.slice(numero_int.toString().length).trim()
                                         }
                                         json_resp['numero'] = numero_int
                                         json_resp['positions'] = [{'point':{type:'Point',coordinates:[lon_osm,lat_osm]}}]


### PR DESCRIPTION
Enlever les espaces dans les suffixes lors de l'envoi d'un signalement BAN de type "Numéro à ajouter".

Exemple : pour le "6 ter", le lien BAN "ajouter un numéro" inclut " ter" comme suffixe au lieu de "ter".